### PR TITLE
Safer example email addresses

### DIFF
--- a/sql/20_chatli.sql
+++ b/sql/20_chatli.sql
@@ -64,6 +64,6 @@ CREATE TABLE attachment
     length INTEGER
 );
 
-INSERT INTO chatli_user (id, username, phone_number, email, password) VALUES (gen_random_uuid(), 'alice', '461234', 'alice@alice.se', 'alice');
-INSERT INTO chatli_user (id, username, phone_number, email, password) VALUES (gen_random_uuid(), 'bob', '462345', 'bob@bob.se', 'bob');
-INSERT INTO chatli_user (id, username, phone_number, email, password) VALUES (gen_random_uuid(), 'ceasar', '463456', 'ceasar@ceasar.se', 'ceasar');
+INSERT INTO chatli_user (id, username, phone_number, email, password) VALUES (gen_random_uuid(), 'alice', '461234', 'alice@example.com', 'alice');
+INSERT INTO chatli_user (id, username, phone_number, email, password) VALUES (gen_random_uuid(), 'bob', '462345', 'bob@example.com', 'bob');
+INSERT INTO chatli_user (id, username, phone_number, email, password) VALUES (gen_random_uuid(), 'ceasar', '463456', 'ceasar@example.com', 'ceasar');


### PR DESCRIPTION
Hey, hope this is OK to suggest a PR - ignore if not 😄 

After talking to @Taure earlier today, our experience is that it is safer to use examples addresses and identifiers that are reserved for testing or documentation (e.g. example.com) that ones which could be assigned IRL (as alice.se is), and whose owners might not appreciate their identifiers being used!

The phone numbers might be subject to a similar consideration. Here in the UK, our regulator reserves a set of MSISDNs which are guaranteed to not be assigned (for use in e.g. film and TV). Happy to propose a second PR to change those too if it is useful.

Not a github regular, so apologies if this PR isn't done the right way - happy to take direction if there's a better way to help. Keep up the great work! 👏 

HTH! 

