### PR TITLE
Pin chatli image to v0.0.2 (kura migration)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     ports:
       - 8095:8095
   chatli:
-    image: ghcr.io/widgrensit/chatli:latest
+    image: ghcr.io/widgrensit/chatli:v0.0.2
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
Bumps the `chatli` service from `:latest` to the explicit **`:v0.0.2`** release - the first chatli build on the kura data layer (replacing raw pgo).

## Why pin instead of staying on :latest
The local docker cache held a 4-month-old `chatli:latest`; the `:latest` tag on ghcr now points to v0.0.2, but a stale cache wouldn't re-pull it. Pinning to `:v0.0.2` forces the verified build and makes the demo reproducible.

## Verification
- `docker compose pull chatli` - pulls `ghcr.io/widgrensit/chatli:v0.0.2` (digest `sha256:522e76ac…`, matching the published release)
- `docker compose config` - valid

The other services (chat_app, ldf) remain on `:latest`.